### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Direct file system access to Obsidian vaults through Model Context Protocol (MCP).
 
+<a href="https://glama.ai/mcp/servers/@quinny1187/obsidian-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@quinny1187/obsidian-mcp/badge" alt="Obsidian Server MCP server" />
+</a>
+
 ## Features
 
 - **Direct vault access** - No plugins or REST API required


### PR DESCRIPTION
This PR adds a badge for the [Obsidian MCP Server](https://glama.ai/mcp/servers/@quinny1187/obsidian-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@quinny1187/obsidian-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@quinny1187/obsidian-mcp/badge" alt="Obsidian Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.